### PR TITLE
`run.sh` caddn -> codyreading/caddn

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -65,7 +65,7 @@ CMD="docker run -it \
     $DATA_VOLUMES \
     $PCDET_VOLUMES \
     --rm \
-    caddn bash
+    codyreading/caddn bash
 "
 echo $CMD
 eval $CMD


### PR DESCRIPTION
When following our tutorial on using Docker, the pulled Docker Image name did not match the command used to run run.sh, resulting in an error with the docker run command.
https://github.com/TRAILab/CaDDN/blob/master/docker/DOCKER.md#get-a-docker-image

```bash
docker pull codyreading/caddn
```

```dockerfile
CMD="docker run -it \
    --runtime=nvidia \
    --net=host \
    --privileged=true \
    --ipc=host \
    --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
    --volume="$XAUTHORITY:/root/.Xauthority:rw" \
    --env="DISPLAY" \
    --env="QT_X11_NO_MITSHM=1" \
    --hostname="inside-DOCKER" \
    --name="CaDDN" \
    --volume $PROJ_DIR/checkpoints:/CaDDN/checkpoints \
    --volume $PROJ_DIR/data:/CaDDN/data \
    --volume $PROJ_DIR/output:/CaDDN/output \
    --volume $PROJ_DIR/tools:/CaDDN/tools \
    --volume $PROJ_DIR/.git:/CaDDN/.git \
    $DATA_VOLUMES \
    $PCDET_VOLUMES \
    --rm \
    caddn bash <--- codyreading/caddn
```